### PR TITLE
Sets the application program name

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import logging
 # Garante que as versões corretas das bibliotecas do sistema operacional sejam carregadas.
 gi.require_version("Gtk", "3.0")
 gi.require_version("WebKit2", "4.1")
-from gi.repository import Gtk, WebKit2
+from gi.repository import Gtk, WebKit2, GLib
 
 # User Agent do Chrome estável no Linux.
 # Necessário para evitar que o WhatsApp web bloqueie o navegador por ser "desconhecido" ou antigo.
@@ -73,6 +73,9 @@ class ClientWindow(Gtk.Window):
             raise error
 
 if __name__ == "__main__":
+    
+    GLib.set_prgname("whatsapp")
+    
     try:
         app = ClientWindow()
         app.connect("destroy", Gtk.main_quit)

--- a/main.py
+++ b/main.py
@@ -58,6 +58,9 @@ class ClientWindow(Gtk.Window):
 
             self.webview = WebKit2.WebView.new_with_context(context)
 
+            self.webview.connect("decide-policy", self._on_decide_policy)
+            self.webview.connect("create", self._on_create_web_view)
+
             # Aplica o User Agent "falso" para passar pelo filtro do WhatsApp.
             settings = self.webview.get_settings()
             settings.set_user_agent(USER_AGENT)
@@ -71,6 +74,36 @@ class ClientWindow(Gtk.Window):
             # Captura falhas na engine do navegador.
             logging.critical(f"Erro fatal ao iniciar WebKit: {error}", exc_info=True)
             raise error
+
+    def _on_decide_policy(self, webview, decision, decision_type):
+        if decision_type == WebKit2.PolicyDecisionType.NAVIGATION_ACTION:
+            navigation_action = decision.get_navigation_action()
+            request = navigation_action.get_request()
+            uri = request.get_uri()
+            
+            if uri and not uri.startswith("https://web.whatsapp.com"):
+                try:
+                    Gtk.show_uri_on_window(self, uri, Gtk.get_current_event_time())
+                    decision.ignore()
+                    logging.info(f"Link externo aberto no navegador: {uri}")
+                    return True
+                except Exception as error:
+                    logging.warning(f"Falha ao abrir link externo: {error}")
+        
+        return False
+
+    def _on_create_web_view(self, webview, navigation_action):
+        request = navigation_action.get_request()
+        uri = request.get_uri()
+        
+        if uri:
+            try:
+                Gtk.show_uri_on_window(self, uri, Gtk.get_current_event_time())
+                logging.info(f"Popup/nova janela aberta no navegador: {uri}")
+            except Exception as error:
+                logging.warning(f"Falha ao abrir popup no navegador: {error}")
+        
+        return None
 
 if __name__ == "__main__":
     


### PR DESCRIPTION
### Description
Sets the program name for the application. This is achieved by calling `GLib.set_prgname("whatsapp")` during the application initialization. Additionally, implements external link handling to open links in the system's default browser instead of within the WebView.

### Screenshots
- before 
<img width="186" height="118" alt="image" src="https://github.com/user-attachments/assets/4e2d4273-4f39-4c83-841c-296c80302dee" />
<img width="128" height="113" alt="image" src="https://github.com/user-attachments/assets/ef305e96-d2df-4353-baea-7926f933568a" />

- after 
<img width="128" height="113" alt="image" src="https://github.com/user-attachments/assets/5ed6b442-655c-4b48-be92-d1eca2a5d9a2" />

### Changes
- Fixed dock integration using `GLib.set_prgname()`
- Added external link handling via `decide-policy` and `create` signals
- Links now open in system default browser instead of within the app